### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
   [![Contact us](https://img.shields.io/badge/Contact%20us-AFF476.svg?style=for-the-badge&logo=mail&logoColor=black)](mailto:hello@themomentum.ai?subject=Apple%20Health%20MCP%20Server%20Inquiry)
   [![Visit Momentum](https://img.shields.io/badge/Visit%20Momentum-1f6ff9.svg?style=for-the-badge&logo=safari&logoColor=white)](https://themomentum.ai)
   [![MIT License](https://img.shields.io/badge/License-MIT-636f5a.svg?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
+
+  <a href="https://glama.ai/mcp/servers/@the-momentum/apple-health-mcp-server">
+    <img width="380" height="200" src="https://glama.ai/mcp/servers/@the-momentum/apple-health-mcp-server/badge" alt="Apple Health Server MCP server" />
+  </a>
 </div>
 
 ## 📋 Table of Contents
@@ -105,7 +109,7 @@ You can run the MCP Server in your LLM Client in two ways:
    ```sh
    make build
    ```
-2. Add the following config to your LLM Client settings (replace `<project-path>` with your local repository path and `<xml-file-name>` with name of your raw data from apple healt file (without `.xml` extension)):
+2. Add the following config to your LLM Client settings (replace `<project-path>` with your local repository path and `<xml-file-name>` with name of your raw data from apple health file (without `.xml` extension)):
    ```json
    {
      "mcpServers": {


### PR DESCRIPTION
This PR adds a badge for the [Apple Health MCP Server](https://glama.ai/mcp/servers/@the-momentum/apple-health-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@the-momentum/apple-health-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@the-momentum/apple-health-mcp-server/badge" alt="Apple Health Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.