### PR TITLE
Converting str to float fallbacks to original value in case of exception

### DIFF
--- a/scripts/xml2es.py
+++ b/scripts/xml2es.py
@@ -24,12 +24,12 @@ class ESIndexer:
             return date_str  # fallback to original if parsing fails
 
     @staticmethod
-    def convert_str2float(value_str: str) -> float:
+    def convert_str2float(value_str: str) -> float | str:
         """Convert value string to numeric type (float)."""
         try:
             return float(value_str)
         except (ValueError, TypeError):
-            return 0.0  # fallback to 0 if parsing fails
+            return value_str  # fallback to original if parsing fails
 
     def parse_xml(self) -> Generator[dict[str, Any], None, None]:
         """


### PR DESCRIPTION
The issue lies with converting the `value` field's values to float, despite some of them containing strings or integers. String values will be now reverted to their original state after causing a ValueError during casting, while pure integer values will still be casted into their float equivalent - which doesn't seem to pose any issues