### PR TITLE
Add Github discussions reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Want to try it out? **[🚀 Getting Started](docs/getting-started.md)**
 - **[🛠️ MCP Tools](docs/mcp-tools.md)** - All available tools
 - **[🗺️ Roadmap](docs/roadmap.md)** - Upcoming features and roadmap
 
+**Need help?** Looking for guidance on use cases or implementation? Don't hesitate to ask your question in our [GitHub discussion forum](https://github.com/the-momentum/apple-health-mcp-server/discussions)! You'll also find interesting use cases, tips, and community insights there.
+
 ## 👥 Contributors
 
 <a href="https://github.com/the-momentum/apple-health-mcp-server/graphs/contributors">


### PR DESCRIPTION
We've been using GitHub Discussions as a knowledge base and source of truth for this project. However, as noted in [this discussion](https://github.com/orgs/community/discussions/3318), GitHub Discussions have poor SEO optimization, making them difficult to discover through search engines.

Additionally, many users may not be aware that Discussions exist for this repository. Adding a reference in the README will improve discoverability and encourage community engagement.