### PR TITLE
fix: use configured DUCKDB_FILENAME instead of hardcoded data.duckdb

### DIFF
--- a/scripts/duckdb_importer.py
+++ b/scripts/duckdb_importer.py
@@ -21,7 +21,7 @@ class ParquetImporter(XMLExporter, DuckDBClient):
         Export xml data from Apple Health export file
         to a .duckdb database with path specified by user
         """
-        con = duckdb.connect("data.duckdb")
+        con = duckdb.connect(str(self.path))
         con.sql("""
             CREATE TABLE IF NOT EXISTS records (
                 type VARCHAR,


### PR DESCRIPTION
The DuckDB importer was hardcoded to create `data.duckdb`, but the app expects `applehealth.duckdb` (from `DUCKDB_FILENAME` config). This required manual renaming after `make duckdb`.

**Change:** Updated `scripts/duckdb_importer.py` to use `self.path` (from `settings.DUCKDB_FILENAME`) instead of hardcoded `"data.duckdb"`.

**Result:** The importer now creates the file with the correct name from the start, matching the configuration.